### PR TITLE
update count-paren.sh to ignore orphan ')'s

### DIFF
--- a/count-paren.sh
+++ b/count-paren.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 input="$(cat /dev/stdin)"
-echo $(( $(grep -o '(' <<< "$input" | wc -l) - $(grep -o ')' <<< $input | wc -l) ))
+echo $(tr -d '\n\r' <<< $input | sed ':loop; s/([^()]*)//g; t loop' | grep -o '(' | wc -l)


### PR DESCRIPTION
Addresses issue #7 

The stream pipeline is as such:
- get rid of line breaks (sed doesn't like it)
- a sed loop to keep removing matched parenthesis pairs (which do not contain parentheses inside)
- count the number of remaining open parentheses
